### PR TITLE
Some simple examples to test empty terminals

### DIFF
--- a/empty-terminals/TFε.fountain
+++ b/empty-terminals/TFε.fountain
@@ -1,0 +1,24 @@
+
+//   fountain.exe parse TFε.fountain  <(echo -n "T") a=1
+// ===> Success
+//   fountain.exe parse TFε.fountain  <(echo -n "F") a=0
+// ===> Success
+//   fountain.exe parse TFε.fountain  <(echo -n "") a=123
+// ===> Success
+
+//   fountain.exe parse TFε.fountain  <(echo -n "T") a=-1
+// ===> Failure 
+//   fountain.exe parse TFε.fountain  <(echo -n "") a=1
+// ===> Failure 
+
+// fountain.exe generate TFε.fountain a=-1
+// ===> Failure 
+
+// All as expected, empty terminals don't appear to be a problem whether 
+// explicit as "", or simply implied after a bare pre-condition.
+
+Goal ::=
+      <. a = 1 .> "T"
+    | <. a = 0 .> "F"
+    | <. a > 1 .>
+;

--- a/empty-terminals/a-n.fountain
+++ b/empty-terminals/a-n.fountain
@@ -1,0 +1,19 @@
+// a{n}  , where n can be 0.
+
+// Generate:
+//    fountain.exe generate empty-terminals/a-n.fountain n=0
+//    fountain.exe generate empty-terminals/a-n.fountain n=7
+
+// Parse:
+//    fountain.exe parse empty-terminals/a-n.fountain <(echo -n "") n=0
+// ===> Success
+//    fountain.exe parse empty-terminals/a-n.fountain <(echo -n "aaaaaaa") n=7
+// ===> Success
+
+// This seems totally fine. Empty terminals cause no problems with generation or parsing.
+
+Goal ::= 
+      <. i = 0 .> <. n > i .> { "a" <. i += 1 .> } <. i >= n .>
+    | <. n = 0 .>
+;
+

--- a/empty-terminals/a-star.fountain
+++ b/empty-terminals/a-star.fountain
@@ -1,0 +1,33 @@
+// a*
+
+// fountain.exe parse a-star.fountain <(echo "aaaa")
+
+
+// Does not generate:
+// fountain.exe: Multiple pre-conditions are satisfied in Alt: (<. a = 1 .> Goal), (<. a = 1 .> "a"), (<. a = 1 .>)
+
+// Does not parse for the same reason:
+//     fountain.exe parse a-star.fountain <(echo "aaaa")
+// fountain.exe: Multiple pre-conditions are satisfied in Alt: (<. a = 1 .> Goal), (<. a = 1 .> "a"), (<. a = 1 .>), with state: Store {store = fromList [], events = []}
+
+
+// Specific parsing:
+//    fountain.exe parse a-star.fountain <(echo -n "") a=2 b=2
+// ===> Success
+
+//    fountain.exe parse a-star.fountain <(echo -n "a") a=2 c=2
+// ===> Success
+
+// but:
+//    fountain.exe parse a-star.fountain <(echo -n "a") a=1 b=2 c=2
+//fountain.exe: Multiple pre-conditions are satisfied in Alt: (<. a = 1 .> Goal), (<. b = 1 .> "a"), (<. c = 1 .>), with state: Store {store = fromList [], events = []}
+// I think I see what's happening here, the set variables are not present on the second pass of Goal so we get the above error. This seems fine.
+
+// This started with all alts sharing the same <. a = 1 .> pre-condition, but morphed into pre-conditions that could be differentiated.
+// It's not giving me the "a"* I wanted. Not sure there is a way to get that.
+
+Goal ::= 
+      <. a = 1 .> Goal
+    | <. b = 1 .> "a"
+    | <. c = 1 .> ""
+;

--- a/empty-terminals/infinite-loop.fountain
+++ b/empty-terminals/infinite-loop.fountain
@@ -1,0 +1,46 @@
+Goal ::=
+     <. a = 0 .> "ε LOOP:" Loop<a>
+   | <. a = 1 .> "a LOOP:" Loop<a>
+   | <. a > 1 .> "NO LOOP"
+;
+
+Loop<a> ::=
+     <. a = 0 .> Loop<a>
+   | <. a = 1 .> "a" Loop<a>
+;
+
+
+// Tests:
+// fountain.exe parse infinite-loop.fountain <(echo -n "NO LOOP") a=1
+// ===> Failure
+
+// fountain.exe parse infinite-loop.fountain <(echo -n "NO LOOP") a=10
+// ===> Success 
+
+// fountain.exe parse infinite-loop.fountain <(echo -n "a LOOP:aaaaaaaa") a=1
+// ===> Failure
+// Is correct, because only an infinte number of "a" will be generated. No finite number is valid.
+
+// fountain.exe parse infinite-loop.fountain <(echo -n "ε LOOP:") a=1
+// ===> Failure
+
+// This is the interesting one:
+// fountain.exe parse infinite-loop.fountain <(echo -n "ε LOOP:") a=0
+//
+// ... no output, does not terminate.
+// Was hoping for a Success since there are infinite ε at the input tail.
+
+
+// fountain.exe parse infinite-loop.fountain <(echo -n "ε LOOP:a") a=0
+//
+// also does not terminate.
+
+
+// Generation behaves as expected with
+// fountain.exe generate infinite-loop.fountain a=0
+//    and
+// fountain.exe generate infinite-loop.fountain a=1
+// not terminating (the desired infinite loops)
+//    and something like
+// fountain.exe generate infinite-loop.fountain a=10
+// ===> NO LOOP

--- a/empty-terminals/nothing-but-ε.fountain
+++ b/empty-terminals/nothing-but-ε.fountain
@@ -1,0 +1,30 @@
+Goal ::= Empty<a> Empty<a>;
+
+
+Empty<a> ::=
+      <. a = 1 .> "" <. a += 3 .>
+    | <. a = 2 .> "" <. a -= 1 .>
+    | <. a = 4 .> <. a -= 4 .>
+;
+
+
+//   fountain.exe parse nothing-but-ε.fountain <(echo -n "") a=1
+// ===> Success
+//   fountain.exe parse nothing-but-ε.fountain <(echo -n "") a=2
+// ===> Success
+//   fountain.exe parse nothing-but-ε.fountain <(echo -n "") a=3
+// ===> Failure 
+//   fountain.exe parse nothing-but-ε.fountain <(echo -n "") a=4
+// ===> Failure 
+
+
+// This generates and parses empty strings and relates the empty input back to the variable correctly.
+// I thought it would be trivial to create a pathological example, but maybe not. Try harder.
+
+// These are nice results (but probably shouldn't be surprising at all...):
+// fountain.exe parse nothing-but-ε.fountain <(echo -n "test") a=1
+// ===> Remaining: "test"
+
+// fountain.exe parse nothing-but-ε.fountain <(echo -n "test") a=3
+// ===> Failure
+

--- a/empty-terminals/same-diff.fountain
+++ b/empty-terminals/same-diff.fountain
@@ -1,0 +1,17 @@
+Goal ::=
+      <. a = b .> "same"
+    | <. a > b .> "diff"
+    | <. a < b .> "diff"
+;
+
+
+// fountain.exe parse same-diff.fountain <(echo -n "diff") a=32 b=34
+// ==> Success
+// fountain.exe parse same-diff.fountain <(echo -n "diff") a=37 b=34
+// ==> Success
+// fountain.exe parse same-diff.fountain <(echo -n "same") a=37 b=37
+// ==> Success
+// fountain.exe parse same-diff.fountain <(echo -n "diff") a=37 b=37
+// ==> Failure
+
+// All as expected.


### PR DESCRIPTION
The parse / generation behaviour seems consistent, and doesn't reveal any problem with empty terminals at all.

Why was I concerned in #2? Are there pathological cases?